### PR TITLE
Remove doom-tree-sitter-fail-gracefully-a

### DIFF
--- a/modules/tools/tree-sitter/config.el
+++ b/modules/tools/tree-sitter/config.el
@@ -2,7 +2,7 @@
 
 (use-package! tree-sitter
   :when (bound-and-true-p module-file-suffix)
-  :hook (prog-mode . tree-sitter-mode)
+  :hook (prog-mode . turn-on-tree-sitter-mode)
   :hook (tree-sitter-after-on . tree-sitter-hl-mode)
   :config
   (require 'tree-sitter-langs)
@@ -10,19 +10,7 @@
   ;; This makes every node a link to a section of code
   (setq tree-sitter-debug-jump-buttons t
         ;; and this highlights the entire sub tree in your code
-        tree-sitter-debug-highlight-jump-region t)
-
-  (defadvice! doom-tree-sitter-fail-gracefully-a (orig-fn &rest args)
-    "Don't break with errors when current major mode lacks tree-sitter support."
-    :around #'tree-sitter-mode
-    (condition-case e
-        (apply orig-fn args)
-      (error
-       (unless (string-match-p (concat "^Cannot find shared library\\|"
-                                       "^No language registered\\|"
-                                       "cannot open shared object file")
-                               (error-message-string e))
-         (signal (car e) (cadr e)))))))
+        tree-sitter-debug-highlight-jump-region t))
 
 (when (featurep! :editor evil +everywhere)
   (use-package! evil-textobj-treesitter


### PR DESCRIPTION
There's no need for it in recent emacs-tree-sitter versions.

`global-tree-sitter-mode` doesn't signal errors for unregistered modes.

Side node: shouldn't the module name be `tree-sitter`? Since it's the official name rather than `treesitter`.