### PR TITLE
Adjust description for textobjs

### DIFF
--- a/modules/tools/tree-sitter/config.el
+++ b/modules/tools/tree-sitter/config.el
@@ -43,4 +43,9 @@
      :textobj "i" (evil-textobj-tree-sitter-get-textobj "conditional.inner") (evil-textobj-tree-sitter-get-textobj "conditional.outer")
 
      :textobj "l" nil nil
-     :textobj "l" (evil-textobj-tree-sitter-get-textobj "loop.inner") (evil-textobj-tree-sitter-get-textobj "loop.outer"))))
+     :textobj "l" (evil-textobj-tree-sitter-get-textobj "loop.inner") (evil-textobj-tree-sitter-get-textobj "loop.outer"))
+    (after! which-key
+      (setq which-key-allow-multiple-replacements t)
+      (pushnew!
+       which-key-replacement-alist
+       '(("" . "\\`+?evil-textobj-tree-sitter-function--\\(.*\\)\\(?:.inner\\|.outer\\)") . (nil . "\\1"))))))


### PR DESCRIPTION
Reduce the length of the description for evil text objects

Not sure if `(setq which-key-allow-multiple-replacements t)` is needed, but it gets around users having their own regexes.